### PR TITLE
Use chips instead of custom badge

### DIFF
--- a/src/materialize-tags.css
+++ b/src/materialize-tags.css
@@ -43,27 +43,6 @@
     .materialize-tags input:focus {
       border: none !important;
       box-shadow: none !important; }
-  .materialize-tags .tag {
-    margin-right: 2px;
-    margin-bottom: 2px;
-    color: white; }
-    .materialize-tags .tag [data-role="remove"] {
-      margin-left: 8px;
-      cursor: pointer; }
-      .materialize-tags .tag [data-role="remove"]:hover {
-        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 1px 2px rgba(0, 0, 0, 0.05); }
-        .materialize-tags .tag [data-role="remove"]:hover:active {
-          box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125); }
-    .materialize-tags .tag.badge {
-      position: relative;
-      right: auto;
-      display: inline-block;
-      background: deepskyblue;
-      font-weight: 300;
-      font-size: .85rem;
-      -webkit-border-radius: 4px;
-      -moz-border-radius: 4px;
-      border-radius: 4px; }
   .materialize-tags .tt-hint {
     position: relative !important; }
   .materialize-tags .tt-input {

--- a/src/materialize-tags.js
+++ b/src/materialize-tags.js
@@ -24,7 +24,7 @@
 
     function tagClass(item)
     {
-        return 'badge';
+        return 'chip';
     }
 
     function itemValue(item)
@@ -198,7 +198,7 @@
             self.itemsArray.push(item);
 
             // add a tag element
-            var $tag = $('<span class="tag ' + htmlEncode(tagClass) + (itemTitle !== null ? ('" title="' + itemTitle) : '') + '">' + htmlEncode(itemText) + '<span class="mdi-content-clear right" data-role="remove"></span></span>');
+            var $tag = $('<span class="' + htmlEncode(tagClass) + (itemTitle !== null ? ('" title="' + itemTitle) : '') + '">' + htmlEncode(itemText) + '<i class="material-icons">close</i></span>');
             $tag.data('item', item);
             self.findInputWrapper().before($tag);
             $tag.after(' ');


### PR DESCRIPTION
Hey,

**Materialize** already have `chips` for tags: http://materializecss.com/chips.html#tag.
They work out of the box with your library. I think that's better to rely on something they maintain.
