### PR TITLE
Set a custom class while adding a new tag

### DIFF
--- a/src/materialize-tags.js
+++ b/src/materialize-tags.js
@@ -223,7 +223,7 @@
             self.itemsArray.push(item);
             
             // Custom class for the tag
-            if(options.tagClass){
+            if(options && options.tagClass){
                 tagClass = options.tagClass;
             }
 

--- a/src/materialize-tags.js
+++ b/src/materialize-tags.js
@@ -221,6 +221,11 @@
 
             // register item in internal array and map
             self.itemsArray.push(item);
+            
+            // Custom class for the tag
+            if(options.tagClass){
+                tagClass = options.tagClass;
+            }
 
             // add a tag element
             var $tag = $('<span class="' + htmlEncode(tagClass) + (itemTitle !== null ? ('" title="' + itemTitle) : '') + '">' + htmlEncode(itemText) + '<i class="material-icons" data-role="remove">close</i></span>');


### PR DESCRIPTION
Now you can have option to set a custom class while adding new tag.

```
$('#mytags').materialtags('add', 'some tag',{tagClass:"chip success-color"});
$('#mytags').materialtags('add', 'some tag',{tagClass:"chip danger-color"});
```